### PR TITLE
machine: support multiple vcpus

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -4,16 +4,17 @@ import (
 	"flag"
 )
 
-func ParseArgs(args []string) (string, string, string, error) {
+func ParseArgs(args []string) (string, string, string, int, error) {
 	kernel := flag.String("k", "./bzImage", "kernel image path")
 	initrd := flag.String("i", "./initrd", "initrd path")
 	params := flag.String("p", "console=ttyS0", "kernel command-line parameters")
+	nCpus := flag.Int("c", 1, "number of cpus")
 
 	flag.Parse()
 
 	if err := flag.CommandLine.Parse(args[1:]); err != nil {
-		return "", "", "", err
+		return "", "", "", 0, err
 	}
 
-	return *kernel, *initrd, *params, nil
+	return *kernel, *initrd, *params, *nCpus, nil
 }

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -17,9 +17,11 @@ func TestParseArg(t *testing.T) {
 		"kernel_path",
 		"-p",
 		"params",
+		"-c",
+		"2",
 	}
 
-	kernel, initrd, params, err := flag.ParseArgs(args)
+	kernel, initrd, params, nCpus, err := flag.ParseArgs(args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,5 +36,9 @@ func TestParseArg(t *testing.T) {
 
 	if params != "params" {
 		t.Fatal("invalid kernel command-line parameters")
+	}
+
+	if nCpus != 2 {
+		t.Fatal("invalid number of vcpus")
 	}
 }

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -177,8 +177,8 @@ func CreateVM(kvmFd uintptr) (uintptr, error) {
 	return ioctl(kvmFd, uintptr(kvmCreateVM), uintptr(0))
 }
 
-func CreateVCPU(vmFd uintptr) (uintptr, error) {
-	return ioctl(vmFd, uintptr(kvmCreateVCPU), uintptr(0))
+func CreateVCPU(vmFd uintptr, vcpuID int) (uintptr, error) {
+	return ioctl(vmFd, uintptr(kvmCreateVCPU), uintptr(vcpuID))
 }
 
 func Run(vcpuFd uintptr) error {

--- a/kvm/kvm_test.go
+++ b/kvm/kvm_test.go
@@ -46,7 +46,7 @@ func TestCreateVM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vcpuFd, err := kvm.CreateVCPU(vmFd)
+	vcpuFd, err := kvm.CreateVCPU(vmFd, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestCreateVCPU(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vcpuFd, err := kvm.CreateVCPU(vmFd)
+	vcpuFd, err := kvm.CreateVCPU(vmFd, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestCreateVCPUWithNoVmFd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = kvm.CreateVCPU(devKVM.Fd())
+	_, err = kvm.CreateVCPU(devKVM.Fd(), 0)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestAddNum(t *testing.T) {
 		UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[0]))),
 	})
 
-	vcpuFd, _ := kvm.CreateVCPU(vmFd)
+	vcpuFd, _ := kvm.CreateVCPU(vmFd, 0)
 	mmapSize, _ := kvm.GetVCPUMMmapSize(devKVM.Fd())
 
 	r, _ := syscall.Mmap(int(vcpuFd), 0, int(mmapSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewAndLoadLinux(t *testing.T) {
 	t.Parallel()
 
-	m, err := machine.New()
+	m, err := machine.New(1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func TestNewAndLoadLinux(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		isContinue, err := m.RunOnce()
+		isContinue, err := m.RunOnce(0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -10,12 +10,12 @@ import (
 )
 
 func main() {
-	kernelPath, initrdPath, params, err := flag.ParseArgs(os.Args)
+	kernelPath, initrdPath, params, nCpus, err := flag.ParseArgs(os.Args)
 	if err != nil {
 		panic(err)
 	}
 
-	m, err := machine.New()
+	m, err := machine.New(nCpus)
 	if err != nil {
 		panic(err)
 	}
@@ -24,11 +24,13 @@ func main() {
 		panic(err)
 	}
 
-	go func() {
-		if err = m.RunInfiniteLoop(); err != nil {
-			panic(err)
-		}
-	}()
+	for i := 0; i < nCpus; i++ {
+		go func() {
+			if err = m.RunInfiniteLoop(0); err != nil {
+				panic(err)
+			}
+		}()
+	}
 
 	restoreMode, err := term.SetRawMode()
 	if err != nil {


### PR DESCRIPTION
FIXME

```text
$ go run . -c 2
[   84.083555][    T1] sched_clock: Marking stable (46532885512, 37549628331)->(106595847866, -22513334023)                                      [10648/11552]
[   88.252816][    T1] devtmpfs: mounted                                                                                                                      
[   91.199975][    T1] Freeing unused kernel image (initmem) memory: 480K                                                                                     
[   97.326338][    T1] Write protecting the kernel read-only data: 8192k                                                                                      
[  103.166722][    T1] Freeing unused kernel image (text/rodata gap) memory: 2044K                                                                            
[  103.888532][    T1] Freeing unused kernel image (rodata/data gap) memory: 1768K                                                                            
[  107.164488][    T1] Run /sbin/init as init process                                                                                                         
[  110.159656][    T1]   with arguments:                                                                                                                      
[  113.723062][    T1]     /sbin/init                                                                                                                         
[  119.145081][    T1]   with environment:                                                                                                                    
[  124.215973][    T1]     HOME=/                                                                                                                             
[  127.166032][    T1]     TERM=linux                                                                                                                         
[  128.166059][   T17] process 17 (getty) attempted a POSIX timer syscall while CONFIG_POSIX_TIMERS is not set                                                
                                                                                                                                                              
[  165.342602][    C0] watchdog: BUG: soft lockup - CPU#0 stuck for 29s! [getty:17]                                                                           
[  165.722783][    C0] CPU: 0 PID: 17 Comm: getty Not tainted 5.10.12 #1                                                                                      
[  166.543265][    C0] RIP: 0010:0xffffffff810f9cde                                                                                                           
[  167.161262][    C0] Code: 48 8b bf 20 02 00 00 e8 29 e1 ff ff 48 89 c3 48 85 c0 74 03 9c 5d fa 48 8b b9 20 02 00 00 e8 ac f3 ff ff 48 85 db 74 10 55 9d <48
> 8d bb c0 00 00 00 5b 5d e9 57 e8 ff ff 5b 5d c3 eb be 41 56 41                                                                                              
[  168.968309][    C0] RSP: 0018:ffffc9000007fd68 EFLAGS: 00000282                                                                                            
[  169.161115][    C0] RAX: 0000000000000007 RBX: ffffffff81971980 RCX: 0000000000000000                                                                      
[  169.162461][    C0] RDX: 00000000000003f9 RSI: 0000000000000001 RDI: ffffffff81971980                                                                      
[  169.797406][    C0] RBP: 0000000000000282 R08: 0000000000000000 R09: ffff888000aab008                                                                      
[  170.841232][    C0] R10: ffffffff8163ad05 R11: 0000000000000000 R12: ffff888000c01402                                                                      
[  171.838195][    C0] R13: ffff888000be5b80 R14: ffff888000bd70b0 R15: ffffc9000006f298
[  172.428233][    C0] FS:  00000000017da8c0(0000) GS:ffffffff81833000(0000) knlGS:0000000000000000
[  173.676137][    C0] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  174.470136][    C0] CR2: 00000000017dceb8 CR3: 0000000000bf2005 CR4: 00000000001706b0
[  175.157356][    C0] Call Trace:
[  175.157793][    C0]  ? 0xffffffff810e7b79
[  175.413148][    C0]  ? 0xffffffff8103f146
[  175.968108][    C0]  ? 0xffffffff810e40aa
[  176.489165][    C0]  ? 0xffffffff810e79e4
[  177.052133][    C0]  ? 0xffffffff810879b5
[  177.590117][    C0]  ? 0xffffffff810887f4
[  178.120181][    C0]  ? 0xffffffff81088920
[  178.655061][    C0]  ? 0xffffffff8113600b
[  179.143161][    C0]  ? 0xffffffff81200079
```