### PR TITLE
do not panic: remove all instances of panic

### DIFF
--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -27,7 +27,11 @@ func TestNewAndLoadLinux(t *testing.T) { // nolint:paralleltest
 	}
 
 	m.GetInputChan()
-	m.InjectSerialIRQ()
+
+	if err := m.InjectSerialIRQ(); err != nil {
+		t.Errorf("m.InjectSerialIRQ: %v != nil", err)
+	}
+
 	m.RunData()
 
 	go func() {

--- a/serial/serial_test.go
+++ b/serial/serial_test.go
@@ -8,7 +8,8 @@ import (
 
 type mockInjector struct{}
 
-func (m *mockInjector) InjectSerialIRQ() {
+func (m *mockInjector) InjectSerialIRQ() error {
+	return nil
 }
 
 func TestNew(t *testing.T) {

--- a/virtio/net.go
+++ b/virtio/net.go
@@ -36,7 +36,7 @@ const (
 )
 
 type IRQInjector interface {
-	InjectVirtioNetIRQ()
+	InjectVirtioNetIRQ() error
 }
 
 type Hdr struct {
@@ -194,9 +194,8 @@ func (v *Net) Rx() error {
 	usedRing.Idx++
 
 	v.Hdr.commonHeader.isr = 0x1
-	v.IRQInjector.InjectVirtioNetIRQ()
 
-	return nil
+	return v.IRQInjector.InjectVirtioNetIRQ()
 }
 
 func (v *Net) TxThreadEntry() {
@@ -256,9 +255,8 @@ func (v *Net) Tx() error {
 	}
 
 	v.Hdr.commonHeader.isr = 0x1
-	v.IRQInjector.InjectVirtioNetIRQ()
 
-	return nil
+	return v.IRQInjector.InjectVirtioNetIRQ()
 }
 
 func (v *Net) IOOutHandler(port uint64, bytes []byte) error {

--- a/virtio/net_test.go
+++ b/virtio/net_test.go
@@ -12,8 +12,10 @@ type mockInjector struct {
 	called bool
 }
 
-func (m *mockInjector) InjectVirtioNetIRQ() {
+func (m *mockInjector) InjectVirtioNetIRQ() error {
 	m.called = true
+
+	return nil
 }
 
 func TestGetDeviceHeader(t *testing.T) {


### PR DESCRIPTION
in main.go, use log.Fatalf, not panic.

In packages, return errors, don't panic.

There's no need to coerce errno from syscall to error,
errno implements error.

Make error messages more descriptive.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>