### PR TITLE
Add support for u-root initrd, because Go deserves more Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,24 @@ vda.img:
 	umount mnt_test
 	file $@
 
+# because a go-based VMM deserves a go initrd.
+# but we include bash (because people like it) and other handy tools.
+# we include the local host tools; the u-root -files command will arrange to bring
+# in all the needed .so
+# You need to have installed the u-root command.
+# GOPATH needs to be set.
+# Something weird here: if I use $SHELL in this it expands to /bin/sh *in this makefile*, but not outside. WTF?
+goinitrd:
+	#echo u-root -defaultsh $(SHELL) -o $(PWD)/goinitrd.cpio -files `which ethtool` -files `which lspci` -files `which $(SHELL)`
+	echo u-root -defaultsh /usr/bin/bash -o $(PWD)/goinitrd.cpio -files `which ethtool` -files `which lspci` -files `which /usr/bin/bash`
+	(cd $(GOPATH)/src/github.com/u-root/u-root && \
+			u-root \
+			-defaultsh /usr/bin/bash \
+			-o $(PWD)/goinitrd.cpio \
+			-files `which ethtool` \
+			-files `which lspci` \
+			-files `which /usr/bin/bash`)
+
 initrd: busybox.config busybox.tar.bz2 busybox.inittab busybox.passwd busybox.rcS pciutils.tar.gz ethtool.tar.gz
 	tar -xf pciutils.tar.gz --one-top-level=_pciutils --strip-components 1
 	$(MAKE) -C _pciutils \


### PR DESCRIPTION
Because a Go kvm needs a Go initrd. For the Go initrd,
we use u-root.

u-root is used in Google and many other data centers for firmware.
For more info see linuxboot.org and/or u-root.org.

But it's also handy for lightweight initrd.

You can get the goinitrd by:
make goinitrd
It builds from Go source in about 6 seconds.

To boot:
gokvm -k your-kernel -i goinitrd.cpio

In about .5 seconds you can see this:
1999/11/30 00:00:00 Welcome to u-root!
                              _
   _   _      _ __ ___   ___ | |_
  | | | |____| '__/ _ \ / _ \| __|
  | |_| |____| | | (_) | (_) | |_
   \__,_|    |_|  \___/ \___/ \__|

init: 1999/11/30 00:00:00 no modules found matching '/lib/modules/*.ko'
defaultsh-5.0# ethtool
ethtool: bad command line argument(s)
For more information run ethtool -h
defaultsh-5.0# lspci
00:00.0 Class 0000: Device 8086:6000
00:01.0 Class 0000: Device 1af4:1000
defaultsh-5.0#

note that we don't build ethtool from source, we just grab the local one,
and u-root works out the .so it needs and brings them in.

If you need more local commands, you can add them pretty easily, e.g.
-files `which vim`

Note that, if you want to save space (typical Google u-root images are
around 3M) you can skip including all the extra commands; u-root has an
equivalent to lspci called pci, which is actually a lot more powerful.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>