### PR TITLE
Change LoadLinux to use io.ReaderAt, not file names

### DIFF
--- a/bootparam/bootparam_test.go
+++ b/bootparam/bootparam_test.go
@@ -1,4 +1,4 @@
-package bootparam
+package bootparam_test
 
 import (
 	"bytes"
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/bobuhiro11/gokvm/bootparam"
 )
 
-func bpnew(n string) (*BootParam, error) {
-	f, err := os.Open("../bzImage")
+func bpnew(n string) (*bootparam.BootParam, error) {
+	f, err := os.Open(n)
 	if err != nil {
-		return nil, fmt.Errorf("Skipping this test: %v", err)
+		return nil, fmt.Errorf("Skipping this test: %w", err)
 	}
 
-	return New(f)
+	return bootparam.New(f)
 }
 
 func TestNew(t *testing.T) {
@@ -55,10 +57,11 @@ func TestAddE820Entry(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping this test: %v", err)
 	}
+
 	b.AddE820Entry(
 		0x1234567812345678,
 		0xabcdefabcdefabcd,
-		E820Ram,
+		bootparam.E820Ram,
 	)
 
 	rawBootParam, _ := b.Bytes()
@@ -66,7 +69,7 @@ func TestAddE820Entry(t *testing.T) {
 		t.Fatalf("invalid e820_entries: %d", rawBootParam[0x1E8])
 	}
 
-	actual := E820Entry{}
+	actual := bootparam.E820Entry{}
 	reader := bytes.NewReader(rawBootParam[0x2D0:])
 
 	if err := binary.Read(reader, binary.LittleEndian, &actual); err != nil {
@@ -81,7 +84,7 @@ func TestAddE820Entry(t *testing.T) {
 		t.Fatalf("invalid e820 size: %v", actual.Size)
 	}
 
-	if actual.Type != E820Ram {
+	if actual.Type != bootparam.E820Ram {
 		t.Fatalf("invalid e820 type: %v", actual.Type)
 	}
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -1,8 +1,9 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"syscall"
@@ -184,21 +185,19 @@ func (m *Machine) RunData() []*kvm.RunData {
 	return m.runs
 }
 
-func (m *Machine) LoadLinux(bzImagePath, initPath, params string) error {
+func (m *Machine) LoadLinux(kernel, initrd io.ReaderAt, params string) error {
 	// Load initrd
-	initrd, err := ioutil.ReadFile(initPath)
-	if err != nil {
-		return err
+	initrdSize, err := initrd.ReadAt(m.mem[initrdAddr:], 0)
+	if err != nil && initrdSize == 0 && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("initrd: (%v, %w)", initrdSize, err)
 	}
-
-	copy(m.mem[initrdAddr:], initrd)
 
 	// Load kernel command-line parameters
 	copy(m.mem[cmdlineAddr:], params)
 	m.mem[cmdlineAddr+len(params)] = 0 // for null terminated string
 
 	// Load Boot Param
-	bootParam, err := bootparam.New(bzImagePath)
+	bootParam, err := bootparam.New(kernel)
 	if err != nil {
 		return err
 	}
@@ -228,7 +227,7 @@ func (m *Machine) LoadLinux(bzImagePath, initPath, params string) error {
 	bootParam.Hdr.VidMode = 0xFFFF                                                                  // Proto ALL
 	bootParam.Hdr.TypeOfLoader = 0xFF                                                               // Proto 2.00+
 	bootParam.Hdr.RamdiskImage = initrdAddr                                                         // Proto 2.00+
-	bootParam.Hdr.RamdiskSize = uint32(len(initrd))                                                 // Proto 2.00+
+	bootParam.Hdr.RamdiskSize = uint32(initrdSize)                                                  // Proto 2.00+
 	bootParam.Hdr.LoadFlags |= bootparam.CanUseHeap | bootparam.LoadedHigh | bootparam.KeepSegments // Proto 2.00+
 	bootParam.Hdr.HeapEndPtr = 0xFE00                                                               // Proto 2.01+
 	bootParam.Hdr.ExtLoaderVer = 0                                                                  // Proto 2.02+
@@ -243,11 +242,6 @@ func (m *Machine) LoadLinux(bzImagePath, initPath, params string) error {
 	copy(m.mem[bootParamAddr:], bytes)
 
 	// Load kernel
-	bzImage, err := ioutil.ReadFile(bzImagePath)
-	if err != nil {
-		return err
-	}
-
 	// copy to g.mem with offest setupsz
 	//
 	// The 32-bit (non-real-mode) kernel starts at offset (setup_sects+1)*512 in
@@ -256,7 +250,11 @@ func (m *Machine) LoadLinux(bzImagePath, initPath, params string) error {
 	//
 	// refs: https://www.kernel.org/doc/html/latest/x86/boot.html#loading-the-rest-of-the-kernel
 	offset := int(bootParam.Hdr.SetupSects+1) * 512
-	copy(m.mem[kernelAddr:], bzImage[offset:])
+
+	kernSize, err := kernel.ReadAt(m.mem[kernelAddr:], int64(offset))
+	if err != nil && kernSize == 0 && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("kernel: (%v, %w)", kernSize, err)
+	}
 
 	for i := range m.vcpuFds {
 		if err = m.initRegs(i); err != nil {

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -22,7 +22,17 @@ func TestNewAndLoadLinux(t *testing.T) { // nolint:paralleltest
 	param := `console=ttyS0 earlyprintk=serial noapic noacpi notsc ` +
 		`lapic tsc_early_khz=2000 pci=realloc=off virtio_pci.force_legacy=1 rdinit=/sbin/init`
 
-	if err = m.LoadLinux("../bzImage", "../initrd", param); err != nil {
+	kern, err := os.Open("../bzImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initrd, err := os.Open("../initrd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = m.LoadLinux(kern, initrd, param); err != nil {
 		t.Fatal(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,17 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
-	if err := m.LoadLinux(kernelPath, initrdPath, params); err != nil {
+	kern, err := os.Open(kernelPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	initrd, err := os.Open(initrdPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := m.LoadLinux(kern, initrd, params); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/virtio/blk_test.go
+++ b/virtio/blk_test.go
@@ -2,6 +2,7 @@ package virtio_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 	"unsafe"
 
@@ -65,6 +66,10 @@ func TestIO(t *testing.T) {
 
 	v, err := virtio.NewBlk("../vda.img", 10, &mockInjector{}, mem)
 	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("../vda.img does not exist, skipping this test")
+		}
+
 		t.Fatalf("err: %v\n", err)
 	}
 


### PR DESCRIPTION
This avoids the double-read of the bzImage but also opens
the possibility of using embedded images.

Here is an example
```
diff --cc main.go
index f5d2475,f5d2475..26cdcdf
--- a/main.go
+++ b/main.go
@@@ -2,7 -2,7 +2,10 @@@ package mai

  import (
  	"bufio"
++	"bytes"
++	_ "embed"
  	"fmt"
++	"io"
  	"log"
  	"os"
  	"sync"
@@@ -12,6 -12,6 +15,12 @@@
  	"github.com/bobuhiro11/gokvm/term"
  )

++//go:embed "bzImage"
++var k []byte
++
++//go:embed "embedinitrd"
++var i []byte
++
  func main() {
  	kernelPath, initrdPath, params, tapIfName, diskPath, nCpus, err := flag.ParseArgs(os.Args)
  	if err != nil {
@@@ -22,14 -22,14 +31,24 @@@
  	if err != nil {
  		log.Fatalf("%v", err)
  	}
--
--	kern, err := os.Open(kernelPath)
--	if err != nil {
--		log.Fatal(err)
++	var kern io.ReaderAt
++	if false {
++		kern, err = os.Open(kernelPath)
++		if err != nil {
++			log.Fatal(err)
++		}
++	} else {
++		kern = bytes.NewReader(k)
  	}
--	initrd, err := os.Open(initrdPath)
--	if err != nil {
--		log.Fatal(err)
++
++	var initrd io.ReaderAt
++	if false {
++		initrd, err = os.Open(initrdPath)
++		if err != nil {
++			log.Fatal(err)
++		}
++	} else {
++		initrd = bytes.NewReader(i)
  	}
  	if err := m.LoadLinux(kern, initrd, params); err != nil {
  		log.Fatalf("%v", err)
Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

```