### PR TITLE
Tracemode

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -38,7 +38,7 @@ func ParseMemSize(s string) (int, error) {
 // device, kernel, initrd, bootparams, tapIfName, disk, memSize, and nCpus.
 // another coding anti-pattern from golangci-lint.
 func ParseArgs(args []string) (kvmPath, kernel, initrd, params,
-	tapIfName, disk string, nCpus, memSize int, 
+	tapIfName, disk string, nCpus, memSize int,
 	trace bool,
 	err error,
 ) {
@@ -69,5 +69,10 @@ func ParseArgs(args []string) (kvmPath, kernel, initrd, params,
 		return
 	}
 
-	return
+	// personally, I think the naked return is easier, it avoids
+	// getting things in the wrong order. But, in fact, there are
+	// too many returns to this function, I think it needs
+	// a config struct.
+	return kvmPath, kernel, initrd, params,
+		tapIfName, disk, nCpus, memSize, trace, nil
 }

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -38,7 +38,9 @@ func ParseMemSize(s string) (int, error) {
 // device, kernel, initrd, bootparams, tapIfName, disk, memSize, and nCpus.
 // another coding anti-pattern from golangci-lint.
 func ParseArgs(args []string) (kvmPath, kernel, initrd, params,
-	tapIfName, disk string, nCpus, memSize int, err error,
+	tapIfName, disk string, nCpus, memSize int, 
+	trace bool,
+	err error,
 ) {
 	flag.StringVar(&kvmPath, "D", "/dev/kvm", "path of kvm device")
 	flag.StringVar(&kernel, "k", "./bzImage", "kernel image path")
@@ -50,6 +52,8 @@ func ParseArgs(args []string) (kvmPath, kernel, initrd, params,
 		`virtio_pci.force_legacy=1 rdinit=/init init=/init`, "kernel command-line parameters")
 	flag.StringVar(&tapIfName, "t", "tap", "name of tap interface")
 	flag.StringVar(&disk, "d", "/dev/zero", "path of disk file (for /dev/vda)")
+
+	flag.BoolVar(&trace, "T", false, "single-step process and print each step")
 
 	flag.IntVar(&nCpus, "c", 1, "number of cpus")
 

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -68,7 +68,7 @@ func TestParseArg(t *testing.T) {
 		t.Errorf("msize: got %#x, want %#x", msize, 1<<30)
 	}
 
-	if ! trace {
+	if !trace {
 		t.Errorf("trace: got %v, want true", trace)
 	}
 }

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -27,9 +27,11 @@ func TestParseArg(t *testing.T) {
 		"disk_path",
 		"-m",
 		"1G",
+		"-T",
+		"true",
 	}
 
-	kvmPath, kernel, initrd, params, tapIfName, disk, nCpus, msize, err := flag.ParseArgs(args)
+	kvmPath, kernel, initrd, params, tapIfName, disk, nCpus, msize, trace, err := flag.ParseArgs(args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,6 +66,10 @@ func TestParseArg(t *testing.T) {
 
 	if msize != 1<<30 {
 		t.Errorf("msize: got %#x, want %#x", msize, 1<<30)
+	}
+
+	if ! trace {
+		t.Errorf("trace: got %v, want true", trace)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/bobuhiro11/gokvm
 
 go 1.17
+
+require (
+	golang.org/x/arch v0.2.0
+	golang.org/x/sys v0.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+golang.org/x/arch v0.2.0 h1:W1sUEHXiJTfjaFJ5SLo0N6lZn+0eO5gWD1MFeTGqQEY=
+golang.org/x/arch v0.2.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -271,31 +271,31 @@ func GetVCPUMMmapSize(kvmFd uintptr) (uintptr, error) {
 }
 
 // GetSRegs gets the special registers for a vcpu.
-func GetSregs(vcpuFd uintptr) (Sregs, error) {
-	sregs := Sregs{}
-	_, err := Ioctl(vcpuFd, uintptr(kvmGetSregs), uintptr(unsafe.Pointer(&sregs)))
+func GetSregs(vcpuFd uintptr) (*Sregs, error) {
+	sregs := &Sregs{}
+	_, err := Ioctl(vcpuFd, uintptr(kvmGetSregs), uintptr(unsafe.Pointer(sregs)))
 
 	return sregs, err
 }
 
 // SetSRegs sets the special registers for a vcpu.
-func SetSregs(vcpuFd uintptr, sregs Sregs) error {
-	_, err := Ioctl(vcpuFd, uintptr(kvmSetSregs), uintptr(unsafe.Pointer(&sregs)))
+func SetSregs(vcpuFd uintptr, sregs *Sregs) error {
+	_, err := Ioctl(vcpuFd, uintptr(kvmSetSregs), uintptr(unsafe.Pointer(sregs)))
 
 	return err
 }
 
 // GetRegs gets the general purpose registers for a vcpu.
-func GetRegs(vcpuFd uintptr) (Regs, error) {
-	regs := Regs{}
-	_, err := Ioctl(vcpuFd, uintptr(kvmGetRegs), uintptr(unsafe.Pointer(&regs)))
+func GetRegs(vcpuFd uintptr) (*Regs, error) {
+	regs := &Regs{}
+	_, err := Ioctl(vcpuFd, uintptr(kvmGetRegs), uintptr(unsafe.Pointer(regs)))
 
 	return regs, err
 }
 
 // SetRegs sets the general purpose registers for a vcpu.
-func SetRegs(vcpuFd uintptr, regs Regs) error {
-	_, err := Ioctl(vcpuFd, uintptr(kvmSetRegs), uintptr(unsafe.Pointer(&regs)))
+func SetRegs(vcpuFd uintptr, regs *Regs) error {
+	_, err := Ioctl(vcpuFd, uintptr(kvmSetRegs), uintptr(unsafe.Pointer(regs)))
 
 	return err
 }

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -62,8 +62,8 @@ const (
 )
 
 var (
-	// ErrUnexpectedReason is any error that we do not understand.
-	ErrUnexpectedEXITReason = errors.New("unexpected kvm exit reason")
+	// ErrUnexpectedExitReason is any error that we do not understand.
+	ErrUnexpectedExitReason = errors.New("unexpected kvm exit reason")
 
 	// ErrDebug is a debug exit, caused by single step or breakpoint.
 	ErrDebug = errors.New("debug exit")

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -62,8 +62,11 @@ const (
 )
 
 var (
+	// ErrUnexpectedReason is any error that we do not understand.
 	ErrUnexpectedEXITReason = errors.New("unexpected kvm exit reason")
-	ErrDebug = errors.New("Debug Exit")
+
+	// ErrDebug is a debug exit, caused by single step or breakpoint.
+	ErrDebug = errors.New("debug exit")
 )
 
 // Regs are registers for both 386 and amd64.

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -61,7 +61,10 @@ const (
 	CPUIDFuncPerMon = 0x0A
 )
 
-var ErrUnexpectedEXITReason = errors.New("unexpected kvm exit reason")
+var (
+	ErrUnexpectedEXITReason = errors.New("unexpected kvm exit reason")
+	ErrDebug = errors.New("Debug Exit")
+)
 
 // Regs are registers for both 386 and amd64.
 // In 386 mode, only some of them are used.
@@ -223,7 +226,7 @@ func SingleStep(vmFd uintptr, onoff bool) error {
 	)
 
 	if onoff {
-		// We used to need this? Not sure. debug[2] = 0x0002 // 0000
+		debug[2] = 0x0002 // 0000
 		debug[0] = Enable | SingleStep
 	}
 

--- a/kvm/kvm_test.go
+++ b/kvm/kvm_test.go
@@ -259,7 +259,7 @@ func TestAddNum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = kvm.SetRegs(vcpuFd, kvm.Regs{
+	if err = kvm.SetRegs(vcpuFd, &kvm.Regs{
 		RIP: 0x1000, RAX: 2, RBX: 2, RFLAGS: 0x2, RCX: 0, RDX: 0, RSI: 0,
 		RDI: 0, RSP: 0, RBP: 0, R8: 0, R9: 0, R10: 0, R11: 0, R12: 0,
 		R13: 0, R14: 0, R15: 0,

--- a/machine/debug_amd64.go
+++ b/machine/debug_amd64.go
@@ -179,7 +179,7 @@ func (m *Machine) WriteWord(cpu int, vaddr uintptr, word uint64) error {
 	return err
 }
 
-// ReadWord reads bytes from the CPUs virtual address space.
+// ReadBytes reads bytes from the CPUs virtual address space.
 func (m *Machine) ReadBytes(cpu int, b []byte, vaddr uintptr) (int, error) {
 	pa, err := m.VtoP(cpu, vaddr)
 	if err != nil {

--- a/machine/debug_amd64.go
+++ b/machine/debug_amd64.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"syscall"
 
 	"github.com/bobuhiro11/gokvm/kvm"
 	"golang.org/x/arch/x86/x86asm"
@@ -19,27 +18,27 @@ var ErrBadRegister = errors.New("bad register")
 
 // Args returns the top nargs args, going down the stack if needed. The max is 6.
 // This is UEFI calling convention.
-func (m *Machine) Args(cpu int, r *syscall.PtraceRegs, nargs int) []uintptr {
-	sp := uintptr(r.Rsp)
+func (m *Machine) Args(cpu int, r *kvm.Regs, nargs int) []uintptr {
+	sp := uintptr(r.RSP)
 
 	switch nargs {
 	case 6:
 		w1, _ := m.ReadWord(cpu, sp+0x28)
 		w2, _ := m.ReadWord(cpu, sp+0x30)
 
-		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9), uintptr(w1), uintptr(w2)}
+		return []uintptr{uintptr(r.RCX), uintptr(r.RDX), uintptr(r.R8), uintptr(r.R9), uintptr(w1), uintptr(w2)}
 	case 5:
 		w1, _ := m.ReadWord(cpu, sp+0x28)
 
-		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9), uintptr(w1)}
+		return []uintptr{uintptr(r.RCX), uintptr(r.RDX), uintptr(r.R8), uintptr(r.R9), uintptr(w1)}
 	case 4:
-		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9)}
+		return []uintptr{uintptr(r.RCX), uintptr(r.RDX), uintptr(r.R8), uintptr(r.R9)}
 	case 3:
-		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8)}
+		return []uintptr{uintptr(r.RCX), uintptr(r.RDX), uintptr(r.R8)}
 	case 2:
-		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx)}
+		return []uintptr{uintptr(r.RCX), uintptr(r.RDX)}
 	case 1:
-		return []uintptr{uintptr(r.Rcx)}
+		return []uintptr{uintptr(r.RCX)}
 	}
 
 	return []uintptr{}
@@ -93,7 +92,7 @@ func (m *Machine) Pop(cpu int, r *kvm.Regs) (uint64, error) {
 }
 
 // Inst retrieves an instruction from the guest, at RIP.
-// It returns an x86asm.Inst, Ptraceregs, a string in GNU syntax, and
+// It returns an x86asm.Inst, Ptraceregs, a string in GNU syntax,
 // and error.
 func (m *Machine) Inst(cpu int) (*x86asm.Inst, *kvm.Regs, string, error) {
 	r, err := m.GetRegs(cpu)

--- a/machine/debug_amd64.go
+++ b/machine/debug_amd64.go
@@ -1,0 +1,171 @@
+package machine
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/bobuhiro11/gokvm/kvm"
+	"golang.org/x/arch/x86/x86asm"
+	"golang.org/x/sys/unix"
+)
+
+// Debug is a normally empty function that enables debug prints.
+// well too bad. var debug = log.Printf // func(string, ...interface{}) {}
+
+// ErrBadRegister indicates a bad register was used.
+var ErrBadRegister = errors.New("bad register")
+
+// Args returns the top nargs args, going down the stack if needed. The max is 6.
+// This is UEFI calling convention.
+func (m *Machine) Args(cpu int, r *syscall.PtraceRegs, nargs int) []uintptr {
+	sp := uintptr(r.Rsp)
+
+	switch nargs {
+	case 6:
+		w1, _ := m.ReadWord(cpu, sp+0x28)
+		w2, _ := m.ReadWord(cpu, sp+0x30)
+
+		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9), uintptr(w1), uintptr(w2)}
+	case 5:
+		w1, _ := m.ReadWord(cpu, sp+0x28)
+
+		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9), uintptr(w1)}
+	case 4:
+		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8), uintptr(r.R9)}
+	case 3:
+		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx), uintptr(r.R8)}
+	case 2:
+		return []uintptr{uintptr(r.Rcx), uintptr(r.Rdx)}
+	case 1:
+		return []uintptr{uintptr(r.Rcx)}
+	}
+
+	return []uintptr{}
+}
+
+// Pointer returns the data pointed to by args[arg].
+func (m *Machine) Pointer(inst *x86asm.Inst, r *kvm.Regs, arg int) (uintptr, error) {
+	mem := inst.Args[arg].(x86asm.Mem)
+	// A Mem is a memory reference.
+	// The general form is Segment:[Base+Scale*Index+Disp].
+	/*
+		type Mem struct {
+			Segment Reg
+			Base    Reg
+			Scale   uint8
+			Index   Reg
+			Disp    int64
+		}
+	*/
+	// debug("ARG[%d] %q m is %#x", inst.Args[arg], mem)
+
+	b, err := GetReg(r, mem.Base)
+	if err != nil {
+		return 0, fmt.Errorf("base reg %v in %v:%w", mem.Base, mem, ErrBadRegister)
+	}
+
+	addr := *b + uint64(mem.Disp)
+
+	x, err := GetReg(r, mem.Index)
+	if err == nil {
+		addr += uint64(mem.Scale) * (*x)
+	}
+
+	// if v, ok := inst.Args[0].(*x86asm.Mem); ok {
+	// debug("computed addr is %#x", addr)
+
+	return uintptr(addr), nil
+}
+
+// Pop pops the stack and returns what was at TOS.
+// It is most often used to get the caller PC (cpc).
+func (m *Machine) Pop(cpu int, r *kvm.Regs) (uint64, error) {
+	cpc, err := m.ReadWord(cpu, uintptr(r.RSP))
+	if err != nil {
+		return 0, err
+	}
+
+	r.RSP += 8
+
+	return cpc, nil
+}
+
+// Inst retrieves an instruction from the guest, at RIP.
+// It returns an x86asm.Inst, Ptraceregs, a string in GNU syntax, and
+// and error.
+func (m *Machine) Inst(cpu int) (*x86asm.Inst, *kvm.Regs, string, error) {
+	r, err := m.GetRegs(cpu)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("Inst:Getregs:%w", err)
+	}
+
+	pc := uintptr(r.RIP)
+
+	// debug("Inst: pc %#x, sp %#x", pc, sp)
+	// We know the PC; grab a bunch of bytes there, then decode and print
+	insn := make([]byte, 16)
+	if _, err := m.ReadBytes(cpu, insn, pc); err != nil {
+		return nil, nil, "", fmt.Errorf("reading PC at #%x:%w", pc, err)
+	}
+
+	d, err := x86asm.Decode(insn, 64)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("decoding %#02x:%w", insn, err)
+	}
+
+	return &d, &r, x86asm.GNUSyntax(d, r.RIP, nil), nil
+}
+
+// Asm returns a string for the given instruction at the given pc.
+func Asm(d *x86asm.Inst, pc uint64) string {
+	return "\"" + x86asm.GNUSyntax(*d, pc, nil) + "\""
+}
+
+// CallInfo provides calling info for a function.
+func CallInfo(_ *unix.SignalfdSiginfo, inst *x86asm.Inst, r *kvm.Regs) string {
+	l := fmt.Sprintf("%s[", show("", r))
+	for _, a := range inst.Args {
+		l += fmt.Sprintf("%v,", a)
+	}
+
+	l += fmt.Sprintf("(%#x, %#x, %#x, %#x)", r.RCX, r.RDX, r.R8, r.R9)
+
+	return l
+}
+
+// WriteWord writes the given word into the guest's virtual address space.
+func (m *Machine) WriteWord(cpu int, vaddr uintptr, word uint64) error {
+	pa, err := m.VtoP(cpu, vaddr)
+	if err != nil {
+		return err
+	}
+
+	var b [8]byte
+
+	binary.LittleEndian.PutUint64(b[:], word)
+	_, err = m.WriteAt(b[:], pa)
+
+	return err
+}
+
+// ReadWord reads bytes from the CPUs virtual address space.
+func (m *Machine) ReadBytes(cpu int, b []byte, vaddr uintptr) (int, error) {
+	pa, err := m.VtoP(cpu, vaddr)
+	if err != nil {
+		return -1, err
+	}
+
+	return m.ReadAt(b, pa)
+}
+
+// ReadWord reads the given word from the cpu's virtual address space.
+func (m *Machine) ReadWord(cpu int, vaddr uintptr) (uint64, error) {
+	var b [8]byte
+	if _, err := m.ReadBytes(cpu, b[:], vaddr); err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint64(b[:]), nil
+}

--- a/machine/debug_amd64_test.go
+++ b/machine/debug_amd64_test.go
@@ -1,0 +1,118 @@
+package machine_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bobuhiro11/gokvm/machine"
+)
+
+func TestDebug(t *testing.T) { // nolint:paralleltest
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
+	if err != nil {
+		t.Fatalf("Open: got %v, want nil", err)
+	}
+
+	rip := uint64(0x1_000_000)
+	if err := m.SetupRegs(rip, 0x10_000, false); err != nil {
+		t.Fatalf("SetupRegs: got %v, want nil", err)
+	}
+
+	r, err := m.GetRegs(0)
+	if err != nil {
+		t.Fatalf("GetRegs: got %v, want nil", err)
+	}
+
+	r.RCX, r.RDX, r.R8, r.R9, r.RSP = 1, 2, 3, 4, 0x1_000_000
+	if err := m.SetRegs(0, r); err != nil {
+		t.Fatalf("SetRegs: got %v, want nil", err)
+	}
+
+	t.Logf("Regs %#x r.RIP %#x", r, r.RIP)
+
+	if r.RIP != rip {
+		t.Fatalf("TestDebug: r.RIP is %#x, want %#x", r.RIP, rip)
+	}
+
+	rsp := uintptr(rip)
+
+	t.Logf("r.RIP %#x, r.RSP %#x", r.RIP, r.RSP)
+
+	if err := m.WriteWord(0, rsp+0x28, 5); err != nil {
+		t.Fatalf("WriteWord(0, %#x, 5): %v != nil", rsp+0x28, err)
+	}
+
+	if v, err := m.ReadWord(0, rsp+0x28); err != nil || v != 5 {
+		t.Fatalf("ReadWord(0, %#x): got (%d, %v), want (5, nil)", rsp+0x28, v, err)
+	}
+
+	if err := m.WriteWord(0, rsp+0x30, 6); err != nil {
+		t.Fatalf("WriteWord(0, %#x, 6): %v != nil", rsp+0x28, err)
+	}
+
+	if v, err := m.ReadWord(0, rsp+0x30); err != nil || v != 6 {
+		t.Fatalf("ReadWord(0, %#x): got (%d, %v), want (6, nil)", rsp+0x28, v, err)
+	}
+
+	if _, err := m.Args(1024, r, 1); err == nil {
+		t.Errorf("m.Args(1024, ...): got nil, want err")
+	}
+
+	if _, err := m.Args(0, r, 800); err == nil {
+		t.Errorf("m.Args(0, r, 800): got nil, want err")
+	}
+
+	args := []uintptr{1, 2, 3, 4, 5, 6}
+	// Just run the Arg code.
+	for i := 1; i < 7; i++ {
+		a, err := m.Args(0, r, i)
+		if err != nil {
+			t.Errorf("m.Args(0, r, %d): %v != nil", i, err)
+		}
+
+		if !reflect.DeepEqual(a[:i], args[:i]) {
+			t.Errorf("m.Args(0, r, %d): got %#x, want %#x, r.RSP %#x", i, a[:i], args[:i], r.RSP)
+		}
+	}
+
+	if _, _, _, err := m.Inst(1024); err == nil {
+		t.Errorf("m.Inst(1024): got nil, want err")
+	}
+
+	i, r, s, err := m.Inst(0)
+	if err != nil {
+		t.Errorf("m.Inst(0): got nil, want err")
+	}
+
+	t.Logf("%v %v %v", i, r, s)
+
+	// See if it looks like Poison
+	s = machine.Asm(i, 0x1_000_000)
+	t.Logf("s at 0x1_000_000 is %s", s)
+
+	if _, err := m.Pointer(i, r, 1024); err == nil {
+		t.Errorf("m.Pointer(arg 1024): got nil, want error")
+	}
+
+	if _, err := m.Pointer(i, r, 1); err == nil {
+		t.Errorf("m.Pointer(i, r, 1): got nil, want err")
+	}
+
+	// Sadly, don't have a use for Pointer (yet)
+
+	if _, err := m.Pop(1024, r); err == nil {
+		t.Errorf("Pop(1024,...): got nil, want err")
+	}
+
+	tos, err := m.ReadWord(0, rsp)
+	if err != nil {
+		t.Fatalf("ReadWord(0, %#x): got %v, want nil", rsp, err)
+	}
+
+	if v, err := m.Pop(0, r); err != nil || v != tos {
+		t.Errorf("Pop(0, r): got (%#x, %v), want (%#x, nil)", v, err, tos)
+	}
+
+	// Not sure what to test, but call it anyway
+	t.Logf("CallInfo: %s", machine.CallInfo(i, r))
+}

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -774,7 +774,7 @@ func (m *Machine) RunOnce(cpu int) (bool, error) {
 			return false, err
 		}
 
-		return false, fmt.Errorf("%w: %s", kvm.ErrUnexpectedEXITReason, exit.String())
+		return false, fmt.Errorf("%w: %s", kvm.ErrUnexpectedExitReason, exit.String())
 	default:
 		if err != nil {
 			return false, err
@@ -784,7 +784,7 @@ func (m *Machine) RunOnce(cpu int) (bool, error) {
 		s, _ := m.GetSRegs(cpu)
 		// another coding anti-pattern from golangci-lint.
 		return false, fmt.Errorf("%w: %v: regs:\n%s",
-			kvm.ErrUnexpectedEXITReason,
+			kvm.ErrUnexpectedExitReason,
 			kvm.ExitType(m.runs[cpu].ExitReason).String(), show("", &s, &r))
 	}
 }
@@ -805,7 +805,7 @@ func (m *Machine) initIOPortHandlers() {
 	}
 
 	funcError := func(port uint64, bytes []byte) error {
-		return fmt.Errorf("%w: unexpected io port 0x%x", kvm.ErrUnexpectedEXITReason, port)
+		return fmt.Errorf("%w: unexpected io port 0x%x", kvm.ErrUnexpectedExitReason, port)
 	}
 
 	// 0xCF9 port can get three values for three types of reset:
@@ -930,7 +930,7 @@ func (m *Machine) ReadAt(b []byte, off int64) (int, error) {
 // WriteAt implements io.WriteAt for the kvm guest memory.
 func (m *Machine) WriteAt(b []byte, off int64) (int, error) {
 	if off > int64(len(m.mem)) {
-		return 0, nil
+		return 0, syscall.EFBIG
 	}
 
 	n := copy(m.mem[off:], b)

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bobuhiro11/gokvm/serial"
 	"github.com/bobuhiro11/gokvm/tap"
 	"github.com/bobuhiro11/gokvm/virtio"
+	"golang.org/x/arch/x86/x86asm"
 )
 
 // InitialRegState GuestPhysAddr                      Binary files [+ offsets in the file]
@@ -64,6 +65,8 @@ const (
 	virtioBlkIRQ = 10
 
 	pageTableBase = 0x30_000
+
+	MinMemSize = 1 << 20
 )
 
 const (
@@ -135,8 +138,20 @@ const (
 
 var ErrZeroSizeKernel = errors.New("kernel is 0 bytes")
 
-// ErrorWriteToCF9 indicates a write to cf9, the standard x86 reset port.
-var ErrorWriteToCF9 = fmt.Errorf("power cycle via 0xcf9")
+// ErrWriteToCF9 indicates a write to cf9, the standard x86 reset port.
+var ErrWriteToCF9 = fmt.Errorf("power cycle via 0xcf9")
+
+// ErrBadVA indicates a bad virtual address was used.
+var ErrBadVA = fmt.Errorf("bad virtual address")
+
+// ErrBadCPU indicates a cpu number is invalid.
+var ErrBadCPU = fmt.Errorf("bad cpu number")
+
+// ErrUnsupported indicates something we do not yet do.
+var ErrUnsupported = fmt.Errorf("unsupported")
+
+// ErrMemTooSmall indicates the requested memory size is too small.
+var ErrMemTooSmall = fmt.Errorf("mem request must be at least 1<<20")
 
 type Machine struct {
 	kvmFd, vmFd    uintptr
@@ -148,7 +163,13 @@ type Machine struct {
 	ioportHandlers [0x10000][2]func(port uint64, bytes []byte) error
 }
 
+// New creates a new KVM. This includes opening the kvm device, creating VM, creating
+// vCPUs, and attaching memory, disk (if needed), and tap (if needed).
 func New(kvmPath string, nCpus int, tapIfName string, diskPath string, memSize int) (*Machine, error) {
+	if memSize < MinMemSize {
+		return nil, fmt.Errorf("memory size %d:%w", memSize, ErrMemTooSmall)
+	}
+
 	m := &Machine{}
 
 	devKVM, err := os.OpenFile(kvmPath, os.O_RDWR, 0o644)
@@ -185,25 +206,26 @@ func New(kvmPath string, nCpus int, tapIfName string, diskPath string, memSize i
 		return m, err
 	}
 
-	for i := 0; i < nCpus; i++ {
+	for cpu := 0; cpu < nCpus; cpu++ {
 		// Create vCPU
-		m.vcpuFds[i], err = kvm.CreateVCPU(m.vmFd, i)
+		m.vcpuFds[cpu], err = kvm.CreateVCPU(m.vmFd, cpu)
 		if err != nil {
 			return m, err
 		}
 
 		// init CPUID
-		if err := m.initCPUID(i); err != nil {
+		if err := m.initCPUID(cpu); err != nil {
 			return m, err
 		}
 
 		// init kvm_run structure
-		r, err := syscall.Mmap(int(m.vcpuFds[i]), 0, int(mmapSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+		r, err := syscall.Mmap(int(m.vcpuFds[cpu]), 0, int(mmapSize),
+			syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
 		if err != nil {
 			return m, err
 		}
 
-		m.runs[i] = (*kvm.RunData)(unsafe.Pointer(&r[0]))
+		m.runs[cpu] = (*kvm.RunData)(unsafe.Pointer(&r[0]))
 	}
 
 	// Another coding anti-pattern reguired by golangci-lint.
@@ -269,11 +291,13 @@ func New(kvmPath string, nCpus int, tapIfName string, diskPath string, memSize i
 	return m, nil
 }
 
+// Translate translates a virtual address for all active CPUs
+// and returns a []*Translate or error.
 func (m *Machine) Translate(vaddr uint64) ([]*Translate, error) {
 	t := make([]*Translate, 0, len(m.vcpuFds))
 
-	for i := range m.vcpuFds {
-		tt, err := GetTranslate(m.vcpuFds[i], vaddr)
+	for cpu := range m.vcpuFds {
+		tt, err := GetTranslate(m.vcpuFds[cpu], vaddr)
 		if err != nil {
 			return t, err
 		}
@@ -284,6 +308,8 @@ func (m *Machine) Translate(vaddr uint64) ([]*Translate, error) {
 	return t, nil
 }
 
+// SetupRegs sets up the general purpose registers,
+// including a RIP and BP.
 func (m *Machine) SetupRegs(rip, bp uint64, amd64 bool) error {
 	for i := range m.vcpuFds {
 		if err := m.initRegs(i, rip, bp); err != nil {
@@ -303,6 +329,8 @@ func (m *Machine) RunData() []*kvm.RunData {
 	return m.runs
 }
 
+// LoadLinux loads a bzImage or ELF file, an optional initrd, and
+// optional params.
 func (m *Machine) LoadLinux(kernel, initrd io.ReaderAt, params string) error {
 	var (
 		DefaultKernelAddr = uint64(highMemBase)
@@ -440,28 +468,33 @@ func (m *Machine) LoadLinux(kernel, initrd io.ReaderAt, params string) error {
 	return nil
 }
 
+// GetInputChan returns a chan <- byte for serial.
 func (m *Machine) GetInputChan() chan<- byte {
 	return m.serial.GetInputChan()
 }
 
-func (m *Machine) GetRegs(i int) (kvm.Regs, error) {
-	return kvm.GetRegs(m.vcpuFds[i])
+// GetRegs gets regs for vCPU.
+func (m *Machine) GetRegs(cpu int) (kvm.Regs, error) {
+	return kvm.GetRegs(m.vcpuFds[cpu])
 }
 
-func (m *Machine) GetSRegs(i int) (kvm.Sregs, error) {
-	return kvm.GetSregs(m.vcpuFds[i])
+// GetSRegs gets sregs for vCPU.
+func (m *Machine) GetSRegs(cpu int) (kvm.Sregs, error) {
+	return kvm.GetSregs(m.vcpuFds[cpu])
 }
 
-func (m *Machine) SetRegs(i int, r kvm.Regs) error {
-	return kvm.SetRegs(m.vcpuFds[i], r)
+// SetRegs sets regs for vCPU.
+func (m *Machine) SetRegs(cpu int, r kvm.Regs) error {
+	return kvm.SetRegs(m.vcpuFds[cpu], r)
 }
 
-func (m *Machine) SetSRegs(i int, s kvm.Sregs) error {
-	return kvm.SetSregs(m.vcpuFds[i], s)
+// SetSRegs sets sregs for vCPU.
+func (m *Machine) SetSRegs(cpu int, s kvm.Sregs) error {
+	return kvm.SetSregs(m.vcpuFds[cpu], s)
 }
 
-func (m *Machine) initRegs(i int, rip, bp uint64) error {
-	regs, err := kvm.GetRegs(m.vcpuFds[i])
+func (m *Machine) initRegs(cpu int, rip, bp uint64) error {
+	regs, err := kvm.GetRegs(m.vcpuFds[cpu])
 	if err != nil {
 		return err
 	}
@@ -472,15 +505,15 @@ func (m *Machine) initRegs(i int, rip, bp uint64) error {
 	// Create stack which will grow down.
 	regs.RSI = bp
 
-	if err := kvm.SetRegs(m.vcpuFds[i], regs); err != nil {
+	if err := kvm.SetRegs(m.vcpuFds[cpu], regs); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *Machine) initSregs(i int, amd64 bool) error {
-	sregs, err := kvm.GetSregs(m.vcpuFds[i])
+func (m *Machine) initSregs(cpu int, amd64 bool) error {
+	sregs, err := kvm.GetSregs(m.vcpuFds[cpu])
 	if err != nil {
 		return err
 	}
@@ -497,7 +530,7 @@ func (m *Machine) initSregs(i int, amd64 bool) error {
 		sregs.CS.DB, sregs.SS.DB = 1, 1
 		sregs.CR0 |= 1 // protected mode
 
-		if err := kvm.SetSregs(m.vcpuFds[i], sregs); err != nil {
+		if err := kvm.SetSregs(m.vcpuFds[cpu], sregs); err != nil {
 			return err
 		}
 
@@ -588,14 +621,14 @@ func (m *Machine) initSregs(i int, amd64 bool) error {
 	seg.Selector = 2 << 3
 	sregs.DS, sregs.ES, sregs.FS, sregs.GS, sregs.SS = seg, seg, seg, seg, seg
 
-	if err := kvm.SetSregs(m.vcpuFds[i], sregs); err != nil {
+	if err := kvm.SetSregs(m.vcpuFds[cpu], sregs); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *Machine) initCPUID(i int) error {
+func (m *Machine) initCPUID(cpu int) error {
 	cpuid := kvm.CPUID{}
 	cpuid.Nent = 100
 
@@ -615,25 +648,27 @@ func (m *Machine) initCPUID(i int) error {
 		}
 	}
 
-	if err := kvm.SetCPUID2(m.vcpuFds[i], &cpuid); err != nil {
+	if err := kvm.SetCPUID2(m.vcpuFds[cpu], &cpuid); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// EnableSingleStep enables single stepping the guest.
+// SingleStep enables single stepping the guest.
 func (m *Machine) SingleStep(onoff bool) error {
-	for i := range m.vcpuFds {
-		if err := kvm.SingleStep(m.vcpuFds[i], onoff); err != nil {
-			return fmt.Errorf("ingle Step %d:%w", i, err)
+	for cpu := range m.vcpuFds {
+		if err := kvm.SingleStep(m.vcpuFds[cpu], onoff); err != nil {
+			return fmt.Errorf("single step %d:%w", cpu, err)
 		}
 	}
 
 	return nil
 }
 
-func (m *Machine) RunInfiniteLoop(i int) error {
+// RunInfiniteLoop runs the guest cpu until there is an error.
+// If the error is ErrExitDebug, this function can be called again.
+func (m *Machine) RunInfiniteLoop(cpu int) error {
 	// https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt
 	// - vcpu ioctls: These query and set attributes that control the operation
 	//   of a single virtual cpu.
@@ -652,32 +687,35 @@ func (m *Machine) RunInfiniteLoop(i int) error {
 	defer runtime.UnlockOSThread()
 
 	for {
-		isContinue, err := m.RunOnce(i)
+		isContinue, err := m.RunOnce(cpu)
 		if isContinue {
 			if err != nil {
 				fmt.Printf("%v\r\n", err)
 			}
+
 			continue
 		}
+
 		if err != nil {
 			return err
 		}
 	}
 }
 
-func (m *Machine) RunOnce(i int) (bool, error) {
-	err := kvm.Run(m.vcpuFds[i])
+// RunOnce runs the guest vCPU until it exits.
+func (m *Machine) RunOnce(cpu int) (bool, error) {
+	err := kvm.Run(m.vcpuFds[cpu])
 
-	exit := kvm.ExitType(m.runs[i].ExitReason)
+	exit := kvm.ExitType(m.runs[cpu].ExitReason)
 
 	switch exit {
 	case kvm.EXITHLT:
 		return false, err
 
 	case kvm.EXITIO:
-		direction, size, port, count, offset := m.runs[i].IO()
+		direction, size, port, count, offset := m.runs[cpu].IO()
 		f := m.ioportHandlers[port][direction]
-		bytes := (*(*[100]byte)(unsafe.Pointer(uintptr(unsafe.Pointer(m.runs[i])) + uintptr(offset))))[0:size]
+		bytes := (*(*[100]byte)(unsafe.Pointer(uintptr(unsafe.Pointer(m.runs[cpu])) + uintptr(offset))))[0:size]
 
 		for i := 0; i < int(count); i++ {
 			if err := f(port, bytes); err != nil {
@@ -693,9 +731,7 @@ func (m *Machine) RunOnce(i int) (bool, error) {
 		// refs https://gist.github.com/mcastelino/df7e65ade874f6890f618dc51778d83a
 		return true, nil
 	case kvm.EXITDEBUG:
-		// if this fails, it fails.
-		r, _ := m.GetRegs(i)
-		return true, fmt.Errorf("%#x:%w", r.RIP, kvm.ErrDebug)
+		return false, kvm.ErrDebug
 
 	case kvm.EXITDCR,
 		kvm.EXITEXCEPTION,
@@ -720,12 +756,12 @@ func (m *Machine) RunOnce(i int) (bool, error) {
 			return false, err
 		}
 
-		r, _ := m.GetRegs(i)
-		s, _ := m.GetSRegs(i)
+		r, _ := m.GetRegs(cpu)
+		s, _ := m.GetSRegs(cpu)
 		// another coding anti-pattern from golangci-lint.
 		return false, fmt.Errorf("%w: %v: regs:\n%s",
 			kvm.ErrUnexpectedEXITReason,
-			kvm.ExitType(m.runs[i].ExitReason).String(), show("", &s, &r))
+			kvm.ExitType(m.runs[cpu].ExitReason).String(), show("", &s, &r))
 	}
 }
 
@@ -765,10 +801,10 @@ func (m *Machine) initIOPortHandlers() {
 	// gokvm a bit more.
 	funcOutbCF9 := func(port uint64, bytes []byte) error {
 		if len(bytes) == 1 && bytes[0] == 0xe {
-			return fmt.Errorf("write 0xe to cf9: %w", ErrorWriteToCF9)
+			return fmt.Errorf("write 0xe to cf9: %w", ErrWriteToCF9)
 		}
 
-		return fmt.Errorf("write %#x to cf9: %w", bytes, ErrorWriteToCF9)
+		return fmt.Errorf("write %#x to cf9: %w", bytes, ErrWriteToCF9)
 	}
 
 	// In ubuntu 20.04 on wsl2, the output to IO port 0x64 continued
@@ -821,6 +857,7 @@ func (m *Machine) initIOPortHandlers() {
 	}
 }
 
+// InjectSerialIRQ injects a serial interrupt.
 func (m *Machine) InjectSerialIRQ() error {
 	if err := kvm.IRQLine(m.vmFd, serialIRQ, 0); err != nil {
 		return err
@@ -833,6 +870,7 @@ func (m *Machine) InjectSerialIRQ() error {
 	return nil
 }
 
+// InjectViortNetIRQ injects a virtio net interrupt.
 func (m *Machine) InjectVirtioNetIRQ() error {
 	if err := kvm.IRQLine(m.vmFd, virtioNetIRQ, 0); err != nil {
 		return err
@@ -845,6 +883,7 @@ func (m *Machine) InjectVirtioNetIRQ() error {
 	return nil
 }
 
+// InjectViortNetIRQ injects a virtio block interrupt.
 func (m *Machine) InjectVirtioBlkIRQ() error {
 	if err := kvm.IRQLine(m.vmFd, virtioBlkIRQ, 0); err != nil {
 		return err
@@ -869,7 +908,9 @@ func (m *Machine) WriteAt(b []byte, off int64) (int, error) {
 	if off > int64(len(m.mem)) {
 		return 0, nil
 	}
+
 	n := copy(m.mem[off:], b)
+
 	return n, nil
 }
 
@@ -919,6 +960,8 @@ type Translate struct {
 // It is incredibly helpful for debugging at startup and detecting
 // corrupted page tables.
 // N.B.: on x86 it appears to ignore vcpufd.
+// And, further, it always says the address is valid.
+// I've no idea why.
 func GetTranslate(vcpuFd uintptr, vaddr uint64) (*Translate, error) {
 	var (
 		kvmTranslate = kvm.IIOWR(0x85, 3*8)
@@ -926,8 +969,114 @@ func GetTranslate(vcpuFd uintptr, vaddr uint64) (*Translate, error) {
 	)
 
 	if _, err := kvm.Ioctl(vcpuFd, kvmTranslate, uintptr(unsafe.Pointer(t))); err != nil {
-		return t, err
+		return t, fmt.Errorf("translate %#x:%w", vaddr, err)
 	}
 
 	return t, nil
+}
+
+// CPUToFD translates a CPU number to an fd.
+func (m *Machine) CPUToFD(cpu int) (uintptr, error) {
+	if cpu > len(m.vcpuFds) {
+		return 0, fmt.Errorf("cpu %d out of range 0-%d:%w", cpu, len(m.vcpuFds), ErrBadCPU)
+	}
+
+	return m.vcpuFds[cpu], nil
+}
+
+// VtoP returns the physical address for a vCPU virtual address.
+func (m *Machine) VtoP(cpu int, vaddr uintptr) (int64, error) {
+	fd, err := m.CPUToFD(cpu)
+	if err != nil {
+		return 0, err
+	}
+
+	t, err := GetTranslate(fd, uint64(vaddr))
+	if err != nil {
+		return -1, err
+	}
+
+	// There can exist a valid translation for memory that does not exist.
+	// For now, we call that an error.
+	if t.Valid == 0 || t.PhysicalAddress > uint64(len(m.mem)) {
+		return -1, fmt.Errorf("%#x:valid not set:%w", vaddr, ErrBadVA)
+	}
+
+	return int64(t.PhysicalAddress), nil
+}
+
+// GetReg gets a pointer to a register in kvm.Regs, given
+// a register number from reg. This used to be a comprehensive
+// case, but golangci-lint disliked the cyclomatic complexity
+// So we only show the few registers we support.
+func GetReg(r *kvm.Regs, reg x86asm.Reg) (*uint64, error) {
+	if reg == x86asm.RAX {
+		return &r.RAX, nil
+	}
+
+	if reg == x86asm.RCX {
+		return &r.RCX, nil
+	}
+
+	if reg == x86asm.RDX {
+		return &r.RDX, nil
+	}
+
+	if reg == x86asm.RBX {
+		return &r.RBX, nil
+	}
+
+	if reg == x86asm.RSP {
+		return &r.RSP, nil
+	}
+
+	if reg == x86asm.RBP {
+		return &r.RBP, nil
+	}
+
+	if reg == x86asm.RSI {
+		return &r.RSI, nil
+	}
+
+	if reg == x86asm.RDI {
+		return &r.RDI, nil
+	}
+
+	if reg == x86asm.R8 {
+		return &r.R8, nil
+	}
+
+	if reg == x86asm.R9 {
+		return &r.R9, nil
+	}
+
+	if reg == x86asm.R10 {
+		return &r.R10, nil
+	}
+
+	if reg == x86asm.R11 {
+		return &r.R11, nil
+	}
+
+	if reg == x86asm.R12 {
+		return &r.R12, nil
+	}
+
+	if reg == x86asm.R13 {
+		return &r.R13, nil
+	}
+
+	if reg == x86asm.R14 {
+		return &r.R14, nil
+	}
+
+	if reg == x86asm.R15 {
+		return &r.R15, nil
+	}
+
+	if reg == x86asm.RIP {
+		return &r.RIP, nil
+	}
+
+	return nil, fmt.Errorf("register %v%w", reg, ErrUnsupported)
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -474,27 +474,27 @@ func (m *Machine) GetInputChan() chan<- byte {
 }
 
 // GetRegs gets regs for vCPU.
-func (m *Machine) GetRegs(cpu int) (kvm.Regs, error) {
+func (m *Machine) GetRegs(cpu int) (*kvm.Regs, error) {
 	fd, err := m.CPUToFD(cpu)
 	if err != nil {
-		return kvm.Regs{}, err
+		return nil, err
 	}
 
 	return kvm.GetRegs(fd)
 }
 
 // GetSRegs gets sregs for vCPU.
-func (m *Machine) GetSRegs(cpu int) (kvm.Sregs, error) {
+func (m *Machine) GetSRegs(cpu int) (*kvm.Sregs, error) {
 	fd, err := m.CPUToFD(cpu)
 	if err != nil {
-		return kvm.Sregs{}, err
+		return nil, err
 	}
 
 	return kvm.GetSregs(fd)
 }
 
 // SetRegs sets regs for vCPU.
-func (m *Machine) SetRegs(cpu int, r kvm.Regs) error {
+func (m *Machine) SetRegs(cpu int, r *kvm.Regs) error {
 	fd, err := m.CPUToFD(cpu)
 	if err != nil {
 		return err
@@ -504,7 +504,7 @@ func (m *Machine) SetRegs(cpu int, r kvm.Regs) error {
 }
 
 // SetSRegs sets sregs for vCPU.
-func (m *Machine) SetSRegs(cpu int, s kvm.Sregs) error {
+func (m *Machine) SetSRegs(cpu int, s *kvm.Sregs) error {
 	fd, err := m.CPUToFD(cpu)
 	if err != nil {
 		return err

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -118,8 +119,8 @@ func TestHalt(t *testing.T) { // nolint:paralleltest
 
 	t.Logf("RunOnce: %v,%v", ok, err)
 
-	if !errors.Is(err, kvm.ErrUnexpectedEXITReason) {
-		t.Errorf("Run: RunOnce(0) exit is %v, not %v", err, kvm.ErrUnexpectedEXITReason)
+	if !errors.Is(err, kvm.ErrUnexpectedExitReason) {
+		t.Errorf("Run: RunOnce(0) exit is %v, not %v", err, kvm.ErrUnexpectedExitReason)
 	}
 
 	if s, err := m.GetSRegs(0); err != nil {
@@ -180,6 +181,10 @@ func TestReadWriteAt(t *testing.T) { // nolint:paralleltest
 	var zeros [8]byte
 	if n, err := m.WriteAt(zeros[:], off); err != nil || n != len(zeros) {
 		t.Fatalf("WriteAt(%#x, %#x): (%d, %v) != (%d, nil)", zeros, off, n, err, len(zeros))
+	}
+
+	if n, err := m.WriteAt(zeros[:], 1<<30); !errors.Is(err, syscall.EFBIG) {
+		t.Fatalf("WriteAt(_, 1<<30): (%d, %v) != (%d, %v)", n, err, 0, syscall.EFBIG)
 	}
 
 	var got [8]byte
@@ -369,8 +374,8 @@ func TestTranslate32(t *testing.T) { // nolint:paralleltest
 
 	t.Logf("Runonce: %v, %v", ok, err)
 
-	if !errors.Is(err, kvm.ErrUnexpectedEXITReason) {
-		t.Errorf("Run: RunOnce(0) exit is %v, not %v", err, kvm.ErrUnexpectedEXITReason)
+	if !errors.Is(err, kvm.ErrUnexpectedExitReason) {
+		t.Errorf("Run: RunOnce(0) exit is %v, not %v", err, kvm.ErrUnexpectedExitReason)
 	}
 
 	if r, err = m.GetRegs(0); err != nil {

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -17,7 +17,7 @@ func TestNewAndLoadLinux(t *testing.T) { // nolint:paralleltest
 		t.Skipf("Skipping test since we are not root")
 	}
 
-	m, err := machine.New("/dev/kvm", 1, "tap", "../vda.img", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "tap", "../vda.img", 1<<29)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestNewAndLoadLinux(t *testing.T) { // nolint:paralleltest
 
 // TestHalt tries to run a Halt instruction in 64-bit mode.
 func TestHalt(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -156,7 +156,7 @@ func TestHalt(t *testing.T) { // nolint:paralleltest
 }
 
 func TestReadWriteAt(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -192,7 +192,7 @@ func TestReadWriteAt(t *testing.T) { // nolint:paralleltest
 }
 
 func TestSingleStepOffOn(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -212,7 +212,7 @@ func TestSingleStepOffOn(t *testing.T) { // nolint:paralleltest
 
 // TestHalt tries to run a Halt instruction in 64-bit mode.
 func TestSetupGetSetRegs(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -249,7 +249,7 @@ func TestSetupGetSetRegs(t *testing.T) { // nolint:paralleltest
 }
 
 func TestSingleStep(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -324,7 +324,7 @@ func TestSingleStep(t *testing.T) { // nolint:paralleltest
 }
 
 func TestTranslate32(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}
@@ -381,7 +381,7 @@ func TestTranslate32(t *testing.T) { // nolint:paralleltest
 }
 
 func TestCPUtoFD(t *testing.T) { // nolint:paralleltest
-	m, err := machine.New("/dev/kvm", 1, "", "", 1<<30)
+	m, err := machine.New("/dev/kvm", 1, "", "", 1<<29)
 	if err != nil {
 		t.Fatalf("Open: got %v, want nil", err)
 	}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	kvmPath, kernelPath, initrdPath, params, tapIfName, diskPath, nCpus, memSize, err := flag.ParseArgs(os.Args)
+	kvmPath, kernelPath, initrdPath, params, tapIfName, diskPath, nCpus, memSize, trace, err := flag.ParseArgs(os.Args)
 	if err != nil {
 		log.Fatalf("ParseArgs: %v", err)
 	}
@@ -68,6 +68,10 @@ func main() {
 	var before byte = 0
 
 	in := bufio.NewReader(os.Stdin)
+
+	if err := m.SingleStep(trace); err != nil {
+		log.Fatalf("SingleStep(%v): %v", trace, err)
+	}
 
 	go func() {
 		for {

--- a/main.go
+++ b/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"sync"
 
 	"github.com/bobuhiro11/gokvm/flag"
+	"github.com/bobuhiro11/gokvm/kvm"
 	"github.com/bobuhiro11/gokvm/machine"
 	"github.com/bobuhiro11/gokvm/term"
 )
@@ -39,18 +41,40 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < nCpus; i++ {
-		fmt.Printf("Start CPU %d of %d\r\n", i, nCpus)
+	if err := m.SingleStep(trace); err != nil {
+		log.Fatalf("Setting trace to %v:%v", trace, err)
+	}
+
+	for cpu := 0; cpu < nCpus; cpu++ {
+		fmt.Printf("Start CPU %d of %d\r\n", cpu, nCpus)
 		wg.Add(1)
 
-		go func(cpuId int) {
-			if err = m.RunInfiniteLoop(cpuId); err != nil {
-				fmt.Printf("%v\n\r", err)
+		go func(cpu int) {
+			for {
+				err = m.RunInfiniteLoop(cpu)
+				if err == nil {
+					continue
+				}
+
+				if !errors.Is(err, kvm.ErrDebug) {
+					break
+				}
+
+				_, r, s, err := m.Inst(cpu)
+				if err != nil {
+					fmt.Printf("disassembling after debug exit:%v", err)
+				}
+
+				fmt.Printf("%#x:%s\r\n", r.RIP, s)
+
+				if err := m.SingleStep(trace); err != nil {
+					log.Fatalf("Setting trace to %v:%v", trace, err)
+				}
 			}
 
 			wg.Done()
-			fmt.Printf("CPU %d exits\n\r", cpuId)
-		}(i)
+			fmt.Printf("CPU %d exits\n\r", cpu)
+		}(cpu)
 	}
 
 	if !term.IsTerminal() {
@@ -70,7 +94,9 @@ func main() {
 	in := bufio.NewReader(os.Stdin)
 
 	if err := m.SingleStep(trace); err != nil {
-		log.Fatalf("SingleStep(%v): %v", trace, err)
+		log.Printf("SingleStep(%v): %v", trace, err)
+
+		return
 	}
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -63,9 +63,9 @@ func main() {
 				_, r, s, err := m.Inst(cpu)
 				if err != nil {
 					fmt.Printf("disassembling after debug exit:%v", err)
+				} else {
+					fmt.Printf("%#x:%s\r\n", r.RIP, s)
 				}
-
-				fmt.Printf("%#x:%s\r\n", r.RIP, s)
 
 				if err := m.SingleStep(trace); err != nil {
 					log.Fatalf("Setting trace to %v:%v", trace, err)


### PR DESCRIPTION

    Add infrastructure for tracing and printing assembly
    
    Now, if gokvm is invoked with -T, you will see traces
    like this:
    
    0x29f3edf:lea 0x1(%rcx),%rsi
    0x29f3ee3:mov %r9,0x10(%rax)
    0x29f3ee7:movzbl (%r8,%rcx,1),%ecx
    0x29f3eec:mov %cl,(%r8,%rdx,1)
    0x29f3ef0:cmp %rsi,0x28(%rax)
    0x29f3ef4:cmove %r10,%rsi
    0x29f3ef8:mov 0x10(%rax),%rdx
    0x29f3efc:mov %rsi,%rcx
    0x29f3eff:sub $0x1,%edi
    
    Much more improvement is possible, but this is a useful first step.
    
    What would be nice: if we had a simple signal handler in gokvm,
    we could use it to turn tracing off and on.
    
    E.g., we could start gokvm, and from another window,
    killall -HUP gokvm
    
    And it would flip the tracing flag.
    
    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>