### PR TITLE
flag/: move discrete variables to a config struct

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -7,6 +7,20 @@ import (
 	"strings"
 )
 
+// Config defines the configuration of the
+// virtual machine, as determined by flags.
+type Config struct {
+	Dev        string
+	Kernel     string
+	Initrd     string
+	Params     string
+	TapIfName  string
+	Disk       string
+	NCPUs      int
+	MemSize    int
+	TraceCount int
+}
+
 // ParseSize parses a size string as number[gGmMkK]. The multiplier is optional,
 // and if not set, the unit passed in is used. The number can be any base and
 // size.
@@ -39,49 +53,39 @@ func ParseSize(s, unit string) (int, error) {
 	return -1, fmt.Errorf("can not parse %q as num[gGmMkK]:%w", s, strconv.ErrSyntax)
 }
 
-// ParseArgs calls flag.Parse and returns strings for
-// device, kernel, initrd, bootparams, tapIfName, disk, memSize, and nCpus.
-// another coding anti-pattern from golangci-lint.
-func ParseArgs(args []string) (kvmPath, kernel, initrd, params,
-	tapIfName, disk string, nCpus, memSize, traceCount int,
-	err error,
-) {
-	flag.StringVar(&kvmPath, "D", "/dev/kvm", "path of kvm device")
-	flag.StringVar(&kernel, "k", "./bzImage", "kernel image path")
-	flag.StringVar(&initrd, "i", "./initrd", "initrd path")
+// ParseArgs calls flag.Parse and a *Config or error.
+func ParseArgs(args []string) (*Config, error) {
+	c := &Config{}
+	flag.StringVar(&c.Dev, "D", "/dev/kvm", "path of kvm device")
+	flag.StringVar(&c.Kernel, "k", "./bzImage", "kernel image path")
+	flag.StringVar(&c.Initrd, "i", "./initrd", "initrd path")
 	//  refs: commit 1621292e73770aabbc146e72036de5e26f901e86 in kvmtool
-	flag.StringVar(&params, "p", `console=ttyS0 earlyprintk=serial noapic noacpi notsc `+
+	flag.StringVar(&c.Params, "p", `console=ttyS0 earlyprintk=serial noapic noacpi notsc `+
 		`debug apic=debug show_lapic=all mitigations=off lapic tsc_early_khz=2000 `+
 		`dyndbg="file arch/x86/kernel/smpboot.c +plf ; file drivers/net/virtio_net.c +plf" pci=realloc=off `+
 		`virtio_pci.force_legacy=1 rdinit=/init init=/init`, "kernel command-line parameters")
-	flag.StringVar(&tapIfName, "t", "tap", "name of tap interface")
-	flag.StringVar(&disk, "d", "/dev/zero", "path of disk file (for /dev/vda)")
+	flag.StringVar(&c.TapIfName, "t", "tap", "name of tap interface")
+	flag.StringVar(&c.Disk, "d", "/dev/zero", "path of disk file (for /dev/vda)")
 
-	flag.IntVar(&nCpus, "c", 1, "number of cpus")
+	flag.IntVar(&c.NCPUs, "c", 1, "number of cpus")
 
 	msize := flag.String("m", "1G", "memory size: as number[gGmM], optional units, defaults to G")
 	tc := flag.String("T", "0", "how many instructions to skip between trace prints -- 0 means tracing disabled")
 
 	flag.Parse()
 
+	var err error
 	if err = flag.CommandLine.Parse(args[1:]); err != nil {
-		return
+		return nil, err
 	}
 
-	if memSize, err = ParseSize(*msize, "g"); err != nil {
-		return
+	if c.MemSize, err = ParseSize(*msize, "g"); err != nil {
+		return nil, err
 	}
 
-	if traceCount, err = ParseSize(*tc, ""); err != nil {
-		return
+	if c.TraceCount, err = ParseSize(*tc, ""); err != nil {
+		return nil, err
 	}
 
-	// personally, I think the naked return is easier, it avoids
-	// getting things in the wrong order. But, in fact, there are
-	// too many returns to this function, I think it needs
-	// a config struct.
-	// And, weirdly, it accepts the naked return on all previous return
-	// statements. Go figure.
-	return kvmPath, kernel, initrd, params,
-		tapIfName, disk, nCpus, memSize, traceCount, nil
+	return c, nil
 }

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -31,45 +31,45 @@ func TestParseArg(t *testing.T) {
 		"1M",
 	}
 
-	kvmPath, kernel, initrd, params, tapIfName, disk, nCpus, msize, tc, err := flag.ParseArgs(args)
+	c, err := flag.ParseArgs(args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if kvmPath != "/dev/kvm" {
+	if c.Dev != "/dev/kvm" {
 		t.Error("invalid kvm  path")
 	}
 
-	if kernel != "kernel_path" {
+	if c.Kernel != "kernel_path" {
 		t.Error("invalid kernel image path")
 	}
 
-	if initrd != "initrd_path" {
+	if c.Initrd != "initrd_path" {
 		t.Error("invalid initrd path")
 	}
 
-	if params != "params" {
+	if c.Params != "params" {
 		t.Error("invalid kernel command-line parameters")
 	}
 
-	if tapIfName != "tap_if_name" {
+	if c.TapIfName != "tap_if_name" {
 		t.Error("invalid name of tap interface")
 	}
 
-	if disk != "disk_path" {
-		t.Errorf("invalid path of disk file: got %v, want %v", disk, "disk_path")
+	if c.Disk != "disk_path" {
+		t.Errorf("invalid path of disk file: got %v, want %v", c.Disk, "disk_path")
 	}
 
-	if nCpus != 2 {
+	if c.NCPUs != 2 {
 		t.Error("invalid number of vcpus")
 	}
 
-	if msize != 1<<30 {
-		t.Errorf("msize: got %#x, want %#x", msize, 1<<30)
+	if c.MemSize != 1<<30 {
+		t.Errorf("msize: got %#x, want %#x", c.MemSize, 1<<30)
 	}
 
-	if tc != 1<<20 {
-		t.Errorf("trace: got %#x, want %#x", tc, 1<<20)
+	if c.TraceCount != 1<<20 {
+		t.Errorf("trace: got %#x, want %#x", c.TraceCount, 1<<20)
 	}
 }
 


### PR DESCRIPTION
As there are more variables, having the return
with so many is getting unwieldy.

As per common practice, create a Config struct
and fill it in from flags.

This allows us to change ParseArgs as needed without having to change the signature.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>