### PR TITLE
add nolint:unused to misjudgment

### DIFF
--- a/kvm/debug_ctl.go
+++ b/kvm/debug_ctl.go
@@ -3,7 +3,7 @@ package kvm
 import "unsafe"
 
 // debugControl controls guest debug.
-type debugControl struct {
+type debugControl struct { // nolint:unused
 	Control  uint32
 	_        uint32
 	DebugReg [8]uint64


### PR DESCRIPTION
Since golangci-lint seems to incorrectly mark it as unused, ignore it.

https://app.travis-ci.com/github/bobuhiro11/gokvm/jobs/594707581
> ./golangci-lint run ./...
> kvm/debug_ctl.go:6:6: type `debugControl` is unused (unused)
> type debugControl struct {
>      ^

Signed-off-by: Nobuhiro MIKI <nob@bobuhiro11.net>