### PR TITLE
Cleanup: IOCTL functions for kvm command codes

### DIFF
--- a/kvm/cpuid.go
+++ b/kvm/cpuid.go
@@ -1,6 +1,8 @@
 package kvm
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // CPUID is the set of CPUID entries returned by GetCPUID.
 type CPUID struct {
@@ -24,7 +26,9 @@ type CPUIDEntry2 struct {
 
 // GetSupportedCPUID gets all supported CPUID entries for a vm.
 func GetSupportedCPUID(kvmFd uintptr, kvmCPUID *CPUID) error {
-	_, err := Ioctl(kvmFd, kvmGetSupportedCPUID, uintptr(unsafe.Pointer(kvmCPUID)))
+	_, err := Ioctl(kvmFd,
+		IIOWR(kvmGetSupportedCPUID, unsafe.Sizeof(kvmCPUID)),
+		uintptr(unsafe.Pointer(kvmCPUID)))
 
 	return err
 }
@@ -34,7 +38,9 @@ func GetSupportedCPUID(kvmFd uintptr, kvmCPUID *CPUID) error {
 // individual vCPUs. This seems odd, but in fact lets code tailor CPUID entries
 // as needed.
 func SetCPUID2(vcpuFd uintptr, kvmCPUID *CPUID) error {
-	_, err := Ioctl(vcpuFd, kvmSetCPUID2, uintptr(unsafe.Pointer(kvmCPUID)))
+	_, err := Ioctl(vcpuFd,
+		IIOW(kvmSetCPUID2, unsafe.Sizeof(kvmCPUID)),
+		uintptr(unsafe.Pointer(kvmCPUID)))
 
 	return err
 }

--- a/kvm/ioctl.go
+++ b/kvm/ioctl.go
@@ -20,11 +20,6 @@ const (
 	nrbits   = 8
 	typebits = 8
 	sizebits = 14
-	dirbits  = 2
-
-	nrmask   = (1 << nrbits) - 1
-	sizemask = (1 << sizebits) - 1
-	dirmask  = (1 << dirbits) - 1
 
 	none      = 0
 	write     = 1
@@ -63,6 +58,6 @@ func IIO(nr uintptr) uintptr {
 // IIOC creates an IIOC ioctl from a direction, nr, and size.
 func IIOC(dir, nr, size uintptr) uintptr {
 	// This is another case of forced wrapping which is considered an anti-pattern in Google.
-	return ((dir & dirmask) << dirshift) | (KVMIO << typeshift) |
-		((nr & nrmask) << nrshift) | ((size & sizemask) << sizeshift)
+	return (dir << dirshift) | (KVMIO << typeshift) |
+		(nr << nrshift) | (size << sizeshift)
 }

--- a/kvm/irq.go
+++ b/kvm/irq.go
@@ -1,6 +1,8 @@
 package kvm
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // irqLevel defines an IRQ as Level? Not sure.
 type irqLevel struct {
@@ -9,20 +11,21 @@ type irqLevel struct {
 }
 
 // IRQLines sets the interrupt line for an IRQ.
-func IRQLine(vmFd uintptr, irq, level uint32) error {
+func IRQLineStatus(vmFd uintptr, irq, level uint32) error {
 	irqLev := irqLevel{
 		IRQ:   irq,
 		Level: level,
 	}
-
-	_, err := Ioctl(vmFd, kvmIRQLine, uintptr(unsafe.Pointer(&irqLev)))
+	_, err := Ioctl(vmFd,
+		IIOWR(kvmIRQLineStatus, unsafe.Sizeof(irqLevel{})),
+		uintptr(unsafe.Pointer(&irqLev)))
 
 	return err
 }
 
 // CreateIRQChip creates an IRQ device (chip) to which to attach interrupts?
 func CreateIRQChip(vmFd uintptr) error {
-	_, err := Ioctl(vmFd, kvmCreateIRQChip, 0)
+	_, err := Ioctl(vmFd, IIO(kvmCreateIRQChip), 0)
 
 	return err
 }
@@ -38,7 +41,9 @@ func CreatePIT2(vmFd uintptr) error {
 	pit := pitConfig{
 		Flags: 0,
 	}
-	_, err := Ioctl(vmFd, kvmCreatePIT2, uintptr(unsafe.Pointer(&pit)))
+	_, err := Ioctl(vmFd,
+		IIOW(kvmCreatePIT2, unsafe.Sizeof(pitConfig{})),
+		uintptr(unsafe.Pointer(&pit)))
 
 	return err
 }

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -6,23 +6,27 @@ import (
 )
 
 const (
-	kvmGetAPIVersion       = 44544
-	kvmCreateVM            = 44545
-	kvmCreateVCPU          = 44609
-	kvmRun                 = 44672
-	kvmGetVCPUMMapSize     = 44548
-	kvmGetSregs            = 0x8138ae83
-	kvmSetSregs            = 0x4138ae84
-	kvmGetRegs             = 0x8090ae81
-	kvmSetRegs             = 0x4090ae82
-	kvmSetUserMemoryRegion = 1075883590
-	kvmSetTSSAddr          = 0xae47
-	kvmSetIdentityMapAddr  = 0x4008AE48
-	kvmCreateIRQChip       = 0xAE60
-	kvmCreatePIT2          = 0x4040AE77
-	kvmGetSupportedCPUID   = 0xC008AE05
-	kvmSetCPUID2           = 0x4008AE90
-	kvmIRQLine             = 0xc008ae67
+	kvmGetAPIVersion     = 0x00
+	kvmCreateVM          = 0x1
+	kvmGetVCPUMMapSize   = 0x04
+	kvmGetSupportedCPUID = 0x05
+
+	kvmCreateVCPU          = 0x41
+	kvmSetUserMemoryRegion = 0x46
+	kvmSetTSSAddr          = 0x47
+	kvmSetIdentityMapAddr  = 0x48
+
+	kvmCreateIRQChip = 0x60
+	kvmIRQLineStatus = 0x67
+	kvmCreatePIT2    = 0x77
+
+	kvmRun      = 0x80
+	kvmGetRegs  = 0x81
+	kvmSetRegs  = 0x82
+	kvmGetSregs = 0x83
+	kvmSetSregs = 0x84
+
+	kvmSetCPUID2 = 0x90
 )
 
 // ExitType is a virtual machine exit type.
@@ -96,12 +100,12 @@ func (r *RunData) IO() (uint64, uint64, uint64, uint64, uint64) {
 
 // GetAPIVersion gets the qemu API version, which changes rarely if at all.
 func GetAPIVersion(kvmFd uintptr) (uintptr, error) {
-	return Ioctl(kvmFd, uintptr(kvmGetAPIVersion), uintptr(0))
+	return Ioctl(kvmFd, IIO(kvmGetAPIVersion), uintptr(0))
 }
 
 // CreateVM creates a KVM from the KVM device fd, i.e. /dev/kvm.
 func CreateVM(kvmFd uintptr) (uintptr, error) {
-	return Ioctl(kvmFd, uintptr(kvmCreateVM), uintptr(0))
+	return Ioctl(kvmFd, IIO(kvmCreateVM), uintptr(0))
 }
 
 // CreateVCPU creates a single virtual CPU from the virtual machine FD.
@@ -110,12 +114,12 @@ func CreateVM(kvmFd uintptr) (uintptr, error) {
 // vmfd from creating a vm from the fd
 // vcpu fd from the vmfd.
 func CreateVCPU(vmFd uintptr, vcpuID int) (uintptr, error) {
-	return Ioctl(vmFd, uintptr(kvmCreateVCPU), uintptr(vcpuID))
+	return Ioctl(vmFd, IIO(kvmCreateVCPU), uintptr(vcpuID))
 }
 
 // Run runs a single vcpu from the vcpufd from createvcpu.
 func Run(vcpuFd uintptr) error {
-	_, err := Ioctl(vcpuFd, uintptr(kvmRun), uintptr(0))
+	_, err := Ioctl(vcpuFd, IIO(kvmRun), uintptr(0))
 	if err != nil {
 		// refs: https://github.com/kvmtool/kvmtool/blob/415f92c33a227c02f6719d4594af6fad10f07abf/kvm-cpu.c#L44
 		if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EINTR) {
@@ -130,5 +134,5 @@ func Run(vcpuFd uintptr) error {
 // required for interacting with the vcpu, as the struct size can change
 // over time.
 func GetVCPUMMmapSize(kvmFd uintptr) (uintptr, error) {
-	return Ioctl(kvmFd, uintptr(kvmGetVCPUMMapSize), uintptr(0))
+	return Ioctl(kvmFd, IIO(kvmGetVCPUMMapSize), uintptr(0))
 }

--- a/kvm/kvm_test.go
+++ b/kvm/kvm_test.go
@@ -374,7 +374,7 @@ func TestIRQLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := kvm.IRQLine(vmFd, 4, 0); err != nil {
+	if err := kvm.IRQLineStatus(vmFd, 4, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/kvm/memory.go
+++ b/kvm/memory.go
@@ -24,14 +24,15 @@ func (r *UserspaceMemoryRegion) SetMemReadonly() {
 
 // SetUserMemoryRegion adds a memory region to a vm -- not a vcpu, a vm.
 func SetUserMemoryRegion(vmFd uintptr, region *UserspaceMemoryRegion) error {
-	_, err := Ioctl(vmFd, uintptr(kvmSetUserMemoryRegion), uintptr(unsafe.Pointer(region)))
+	_, err := Ioctl(vmFd, IIOW(kvmSetUserMemoryRegion, unsafe.Sizeof(UserspaceMemoryRegion{})),
+		uintptr(unsafe.Pointer(region)))
 
 	return err
 }
 
 // SetTSSAddr sets the Task Segment Selector for a vm.
 func SetTSSAddr(vmFd uintptr) error {
-	_, err := Ioctl(vmFd, kvmSetTSSAddr, 0xffffd000)
+	_, err := Ioctl(vmFd, IIO(kvmSetTSSAddr), 0xffffd000)
 
 	return err
 }
@@ -39,7 +40,7 @@ func SetTSSAddr(vmFd uintptr) error {
 // SetIdentityMapAddr sets the address of a 4k-sized-page for a vm.
 func SetIdentityMapAddr(vmFd uintptr) error {
 	var mapAddr uint64 = 0xffffc000
-	_, err := Ioctl(vmFd, kvmSetIdentityMapAddr, uintptr(unsafe.Pointer(&mapAddr)))
+	_, err := Ioctl(vmFd, IIOW(kvmSetIdentityMapAddr, 8), uintptr(unsafe.Pointer(&mapAddr)))
 
 	return err
 }

--- a/kvm/registers.go
+++ b/kvm/registers.go
@@ -28,14 +28,14 @@ type Regs struct {
 // GetRegs gets the general purpose registers for a vcpu.
 func GetRegs(vcpuFd uintptr) (*Regs, error) {
 	regs := &Regs{}
-	_, err := Ioctl(vcpuFd, uintptr(kvmGetRegs), uintptr(unsafe.Pointer(regs)))
+	_, err := Ioctl(vcpuFd, IIOR(kvmGetRegs, unsafe.Sizeof(Regs{})), uintptr(unsafe.Pointer(regs)))
 
 	return regs, err
 }
 
 // SetRegs sets the general purpose registers for a vcpu.
 func SetRegs(vcpuFd uintptr, regs *Regs) error {
-	_, err := Ioctl(vcpuFd, uintptr(kvmSetRegs), uintptr(unsafe.Pointer(regs)))
+	_, err := Ioctl(vcpuFd, IIOW(kvmSetRegs, unsafe.Sizeof(Regs{})), uintptr(unsafe.Pointer(regs)))
 
 	return err
 }
@@ -65,14 +65,14 @@ type Sregs struct {
 // GetSRegs gets the special registers for a vcpu.
 func GetSregs(vcpuFd uintptr) (*Sregs, error) {
 	sregs := &Sregs{}
-	_, err := Ioctl(vcpuFd, uintptr(kvmGetSregs), uintptr(unsafe.Pointer(sregs)))
+	_, err := Ioctl(vcpuFd, IIOR(kvmGetSregs, unsafe.Sizeof(Sregs{})), uintptr(unsafe.Pointer(sregs)))
 
 	return sregs, err
 }
 
 // SetSRegs sets the special registers for a vcpu.
 func SetSregs(vcpuFd uintptr, sregs *Sregs) error {
-	_, err := Ioctl(vcpuFd, uintptr(kvmSetSregs), uintptr(unsafe.Pointer(sregs)))
+	_, err := Ioctl(vcpuFd, IIOW(kvmSetSregs, unsafe.Sizeof(Sregs{})), uintptr(unsafe.Pointer(sregs)))
 
 	return err
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -854,11 +854,11 @@ func (m *Machine) initIOPortHandlers() {
 
 // InjectSerialIRQ injects a serial interrupt.
 func (m *Machine) InjectSerialIRQ() error {
-	if err := kvm.IRQLine(m.vmFd, serialIRQ, 0); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, serialIRQ, 0); err != nil {
 		return err
 	}
 
-	if err := kvm.IRQLine(m.vmFd, serialIRQ, 1); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, serialIRQ, 1); err != nil {
 		return err
 	}
 
@@ -867,11 +867,11 @@ func (m *Machine) InjectSerialIRQ() error {
 
 // InjectViortNetIRQ injects a virtio net interrupt.
 func (m *Machine) InjectVirtioNetIRQ() error {
-	if err := kvm.IRQLine(m.vmFd, virtioNetIRQ, 0); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, virtioNetIRQ, 0); err != nil {
 		return err
 	}
 
-	if err := kvm.IRQLine(m.vmFd, virtioNetIRQ, 1); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, virtioNetIRQ, 1); err != nil {
 		return err
 	}
 
@@ -880,11 +880,11 @@ func (m *Machine) InjectVirtioNetIRQ() error {
 
 // InjectViortNetIRQ injects a virtio block interrupt.
 func (m *Machine) InjectVirtioBlkIRQ() error {
-	if err := kvm.IRQLine(m.vmFd, virtioBlkIRQ, 0); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, virtioBlkIRQ, 0); err != nil {
 		return err
 	}
 
-	if err := kvm.IRQLine(m.vmFd, virtioBlkIRQ, 1); err != nil {
+	if err := kvm.IRQLineStatus(m.vmFd, virtioBlkIRQ, 1); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Change arbitrary command codes into proper IOCTL functions for better readability.

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>