### PR TITLE
Improve struct handling

### DIFF
--- a/kvm/kvm_test.go
+++ b/kvm/kvm_test.go
@@ -86,14 +86,16 @@ func TestCPUID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	CPUID := kvm.CPUID{}
-	CPUID.Nent = 100
+	CPUID := kvm.CPUID{
+		Nent:    100,
+		Entries: make([]kvm.CPUIDEntry2, 100),
+	}
 
 	if err := kvm.GetSupportedCPUID(devKVM.Fd(), &CPUID); err != nil {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < len(CPUID.Entries); i++ {
 		CPUID.Entries[i].Eax = kvm.CPUIDFeatures
 		CPUID.Entries[i].Ebx = 0x4b4d564b // KVMK
 		CPUID.Entries[i].Ecx = 0x564b4d56 // VMKV
@@ -635,7 +637,7 @@ func TestGetEmulatedCPUID(t *testing.T) {
 
 	kvmCPUID := &kvm.CPUID{
 		Nent:    100,
-		Entries: [100]kvm.CPUIDEntry2{},
+		Entries: make([]kvm.CPUIDEntry2, 100),
 	}
 
 	if err := kvm.GetEmulatedCPUID(devKVM.Fd(), kvmCPUID); err != nil {

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -583,8 +583,10 @@ func (m *Machine) initSregs(vcpufd uintptr, amd64 bool) error {
 }
 
 func (m *Machine) initCPUID(cpu int) error {
-	cpuid := kvm.CPUID{}
-	cpuid.Nent = 100
+	cpuid := kvm.CPUID{
+		Nent:    100,
+		Entries: make([]kvm.CPUIDEntry2, 100),
+	}
 
 	if err := kvm.GetSupportedCPUID(m.kvmFd, &cpuid); err != nil {
 		return err


### PR DESCRIPTION
Introduce kvm.kvmSendReceive function.

This function wraps Ioctl-function to serialize any data given. It allows the use of slices in places we use fixed size arrays in structs. Deserialization needs to be handeled in the `kvm.<OpFunc>`. 

I implemented the use of this function for some kvm functions as proof of concept. If you like it, I will adapt all kvm functions to it.