### PR TITLE
add rule to check for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,23 @@ vda.img:
 	genext2fs -b 1024 -d ${dir} $@
 	file $@
 
+# checkbinaries runs which on all the commands we want to include.
+# Be sure to keep it up to date if you add new commands to the initrd
+# rule below.
+checkbinaries:
+	@which ethtool
+	@which lspci
+	@which lsblk
+	@which hexdump
+	@which mount
+	@which bash
+	@which nohup
+	@which clear
+	@which tic
+	@which awk
+	@which grep
+	@which cut
+
 # because a go-based VMM deserves a go initrd.
 # but we include bash (because people like it) and other handy tools.
 # we include the local host tools; the u-root -files command will arrange to bring
@@ -22,7 +39,7 @@ vda.img:
 # You need to have installed the u-root command.
 # GOPATH needs to be set.
 # Something weird here: if I use $SHELL in this it expands to /bin/sh *in this makefile*, but not outside. WTF?
-initrd:
+initrd: checkbinaries
 	(cd $(GOPATH)/src/github.com/u-root/u-root && \
 			u-root \
 			-defaultsh `which bash` \


### PR DESCRIPTION
the u-root command in the Makefile uses the pattern u-root -files command
for many commands.

Confusing problems ensue if the command is not there: the command expands to
u-root -files -files

Add a rule to run which for all the binaries, which will fail in a more understandable way.