### PR TITLE
scripts: Add get_initrd.bash to speed up CI jobs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,34 +32,8 @@ checkbinaries:
 	@which grep
 	@which cut
 
-# because a go-based VMM deserves a go initrd.
-# but we include bash (because people like it) and other handy tools.
-# we include the local host tools; the u-root -files command will arrange to bring
-# in all the needed .so
-# You need to have installed the u-root command.
-# GOPATH needs to be set.
-# Something weird here: if I use $SHELL in this it expands to /bin/sh *in this makefile*, but not outside. WTF?
 initrd: checkbinaries
-	(cd $(GOPATH)/src/github.com/u-root/u-root && \
-			u-root \
-			-defaultsh `which bash` \
-			-o $(PWD)/initrd \
-			-files `which ethtool` \
-			-files `which lspci` \
-			-files `which lsblk` \
-			-files `which hexdump` \
-			-files `which mount` \
-			-files `which bash` \
-			-files `which nohup` \
-			-files `which clear` \
-			-files `which tic` \
-			-files `which awk` \
-			-files `which grep` \
-			-files `which cut` \
-			-files "/usr/share/terminfo/l/linux-c:/usr/share/terminfo/l/linux" \
-			-files "/usr/share/misc/pci.ids" \
-			-files "$(PWD)/.bashrc:.bashrc" \
-			core boot github.com/u-root/u-root/cmds/exp/srvfiles)
+	./scripts/get_initrd.bash
 
 bzImage: linux.config
 	./scripts/get_kernel.bash

--- a/scripts/get_initrd.bash
+++ b/scripts/get_initrd.bash
@@ -1,0 +1,45 @@
+#!/bin/bash -x
+# ----------------------------------------------------------------------
+# get_initrd.bash - download or build initrd
+# ----------------------------------------------------------------------
+
+# Download pre-compiled initrd
+curl -s -O -L -C - --retry 5 \
+  https://github.com/bobuhiro11/bins/raw/main/gokvm/initrd
+
+# Check that initrd was compiled with latest get_initrd.bash.
+md5sum=$(md5sum ./scripts/get_initrd.bash | awk '{print $1}')
+lsinitramfs initrd | grep $md5sum
+
+# If needed, we build initrd in local
+if [ $? -ne 0 ]; then
+  # because a go-based VMM deserves a go initrd.
+  # but we include bash (because people like it) and other handy tools.
+  # we include the local host tools; the u-root -files command will arrange to bring
+  # in all the needed .so
+  # You need to have installed the u-root command.
+  # GOPATH needs to be set.
+  # Something weird here: if I use $SHELL in this it expands to /bin/sh *in this makefile*, but not outside. WTF?
+  pwd=$(pwd)
+  (cd ${GOPATH}/src/github.com/u-root/u-root && \
+    u-root \
+    -defaultsh `which bash` \
+    -o ${pwd}/initrd \
+    -files `which ethtool` \
+    -files `which lspci` \
+    -files `which lsblk` \
+    -files `which hexdump` \
+    -files `which mount` \
+    -files `which bash` \
+    -files `which nohup` \
+    -files `which clear` \
+    -files `which tic` \
+    -files `which awk` \
+    -files `which grep` \
+    -files `which cut` \
+    -files "/usr/share/terminfo/l/linux-c:/usr/share/terminfo/l/linux" \
+    -files "/usr/share/misc/pci.ids" \
+    -files "${pwd}/.bashrc:.bashrc" \
+    -files "/dev/null:$md5sum" \
+    core boot github.com/u-root/u-root/cmds/exp/srvfiles)
+fi


### PR DESCRIPTION
The CI job shows that building initrd takes 1 minute [1]. So we download it using the same approach as bzImage.

[1]: https://app.travis-ci.com/github/bobuhiro11/gokvm/jobs/607617895