### PR TITLE
do not start goroutines in packages; use errgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.21
 
 require (
 	golang.org/x/arch v0.2.0
+	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 golang.org/x/arch v0.2.0 h1:W1sUEHXiJTfjaFJ5SLo0N6lZn+0eO5gWD1MFeTGqQEY=
 golang.org/x/arch v0.2.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/serial/serial_test.go
+++ b/serial/serial_test.go
@@ -3,6 +3,8 @@ package serial_test
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/bobuhiro11/gokvm/serial"
@@ -79,7 +81,11 @@ func TestStartSerial(t *testing.T) {
 
 	in := bufio.NewReader(&bufIn)
 
-	s.StartSerial(*in, func() {}, injectFunc)
+	go func() {
+		if err := s.Start(*in, func() {}, injectFunc); !errors.Is(err, io.EOF) {
+			t.Errorf("s.Start(): got %v, want %v", err, io.EOF)
+		}
+	}()
 
 	if err := s.In(serial.COM1Addr+3, []byte{0}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Starting goroutines in packages is now frowned upon. Also, we can use errgroup to simplify the code.

This is not quite bringing them up to the top;
but they are in vmm, and they do use errgroup.

Now, when you do
^Ax
it does not call os.Exit(0), which is better behavior.

But we need to add context support, so we can cancel everything when either a processor or the console exits.